### PR TITLE
240625 hotfix kakaoLogin

### DIFF
--- a/src/main/java/com/wooin/dailyone/config/AuthenticationConfig.java
+++ b/src/main/java/com/wooin/dailyone/config/AuthenticationConfig.java
@@ -30,7 +30,8 @@ public class AuthenticationConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
-                .requestMatchers("/api/*/users/join", "/api/*/users/login","/api/v1/social-login/kakao/callback");
+                .requestMatchers( "/api/*/users/login","/api/v1/social-login/kakao/callback");
+        // "/api/*/users/join", 임시 삭제. 회원가입시 @CreatedBy가 동작되지 않음. SecurityContextHolder를 생성하지 않는것으로 보임.
     }
 
     @Bean

--- a/src/main/java/com/wooin/dailyone/util/ClassUtils.java
+++ b/src/main/java/com/wooin/dailyone/util/ClassUtils.java
@@ -9,6 +9,6 @@ public class ClassUtils {
 
     public static <T> T getSafeCastInstance(Object o, Class<T> clazz) {
         Optional<T> result = clazz != null && clazz.isInstance(o) ? Optional.of(clazz.cast(o)) : Optional.empty();
-        return result.orElseThrow(() -> new DailyoneException(ErrorCode.INTERNAL_SERVER_ERROR, "incorrect Casting"));
+        return result.orElseThrow(() -> new DailyoneException(ErrorCode.INTERNAL_SERVER_ERROR, "incorrect Casting :"+clazz.getSimpleName()));
     }
 }


### PR DESCRIPTION
- ignoring()에서 회원가입 uri 삭제. 해당 기능이 SecurityContextHolder를 생성하지 않게하는것으로 보임
- this close #43 